### PR TITLE
Compilation error due to use of "errno" without <errno.h> 

### DIFF
--- a/pkgin.h
+++ b/pkgin.h
@@ -41,6 +41,7 @@
 #endif
 
 #include <fetch.h>
+#include <errno.h>
 #include "messages.h"
 #include "pkgindb.h"
 #include "tools.h"


### PR DESCRIPTION
Error due to commit 7741fe201eea58628562cc833e16e034694cfa72 (management errors on mkdir)
Check the include is well positioned for the main developer.
