### PR TITLE
pkg_str: Fix depends like clutter-gtk0.10>=0.10

### DIFF
--- a/pkg_str.c
+++ b/pkg_str.c
@@ -188,8 +188,11 @@ cleanup_version(char *pkgname)
 	if ((exten = strrchr(pkgname, '-')) == NULL)
 		return;
 
-	/* -something has a dot, it's a version number */
-	if (strchr(exten, '.') != NULL)
+	/*
+	 * -something has a dot, it's a version number
+	 * unless it was something like clutter-gtk0.10
+	 */
+	if (isdigit((int)exten[1]) && strchr(exten, '.') != NULL)
 		*exten = '\0';
 }
 


### PR DESCRIPTION
The previous coding considered "gtk0.10" part as a version number
and incorrectly chopped it.
