### PR TITLE
apt-file like new 'search-file' command

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -6,7 +6,7 @@ VERSION=	@PACKAGE_VERSION@
 SRCS=		main.c summary.c tools.c pkgindb.c depends.c actions.c \
 		pkglist.c download.c order.c impact.c autoremove.c fsops.c \
 		pkgindb_queries.c pkg_str.c sqlite_callbacks.c selection.c \
-		pkg_check.c pkg_infos.c
+		pkg_check.c pkg_infos.c pkg_files.c
 # included from libinstall
 SRCS+=		automatic.c decompress.c dewey.c fexec.c global.c \
 		opattern.c pkgdb.c var.c

--- a/cmd.h
+++ b/cmd.h
@@ -72,6 +72,8 @@ static struct command {
 	  PKG_SHNOKP_CMD },
 	{ "search", "se", "Search for a package.",
 	  PKG_SRCH_CMD },
+	{ "search-file", "sef", "Search for a package containg file.",
+	  PKG_SRCHF_CMD },
 	{ "clean", "cl", "Clean packages cache.",
 	  PKG_CLEAN_CMD },
 	{ "autoremove", "ar", "Autoremove orphan dependencies.",

--- a/fsops.c
+++ b/fsops.c
@@ -99,6 +99,14 @@ clean_cache()
 }
 
 void
+create_dir(char *path)
+{
+	if(-1 == mkdir(path, 0755) && errno != EEXIST) 
+		errx(EXIT_FAILURE, MSG_MKDIR_FAILED, path,
+						strerror(errno));
+}
+
+void
 create_dirs()
 {
 	/* create database repository */

--- a/fsops.c
+++ b/fsops.c
@@ -99,7 +99,7 @@ clean_cache()
 }
 
 void
-create_dir(char *path)
+create_dir(const char *path)
 {
 	if(-1 == mkdir(path, 0755) && errno != EEXIST) 
 		errx(EXIT_FAILURE, MSG_MKDIR_FAILED, path,

--- a/main.c
+++ b/main.c
@@ -173,6 +173,8 @@ main(int argc, char *argv[])
 
 	switch (ch) {
 	case PKG_UPDT_CMD: /* update packages db */
+		if (update_pkg_files() == EXIT_FAILURE)
+			errx(EXIT_FAILURE, MSG_DONT_HAVE_RIGHTS);
 		if (updb_all) /* no need to do it twice */
 			break;
 		if (update_db(REMOTE_SUMMARY, NULL) == EXIT_FAILURE)
@@ -235,6 +237,10 @@ main(int argc, char *argv[])
 	case PKG_SRCH_CMD: /* search for package */
 		missing_param(argc, 2, MSG_MISSING_SRCH);
 		rc = search_pkg(argv[1]);
+		break;
+	case PKG_SRCHF_CMD: /* search for package */
+		missing_param(argc, 2, MSG_MISSING_SRCH);
+		rc = search_pkg_file(argv[1]);
 		break;
 	case PKG_CLEAN_CMD: /* clean pkgin's packages cache */
 		clean_cache();

--- a/messages.h
+++ b/messages.h
@@ -158,6 +158,7 @@ please re-run %s with a package name matching one of the following:\n"
 #define MSG_INVALID_REPOS "Invalid repository: %s"
 #define MSG_MKDIR_DB_REPOSITORY_FAILED "Failed to create database repository %s\n"
 #define MSG_MKDIR_CACHE_REPOSITORY_FAILED "Failed to create cache repository %s\n"
+#define MSG_MKDIR_FAILED "Failed to create directory %s: %s\n"
 
 /* selection.c */
 #define MSG_EMPTY_IMPORT_LIST "Empty import list."

--- a/messages.h
+++ b/messages.h
@@ -166,3 +166,6 @@ please re-run %s with a package name matching one of the following:\n"
 /* pkg_check.c */
 #define MSG_NO_PROV_REQ "Nothing %s by %s.\n"
 #define MSG_FILES_PROV_REQ "Files %s by %s:\n"
+
+/* pkg_files.c */
+#define MSG_PKG_FILES_IS_UP_TO_DATE "pkg_files for %s is up-to-date\n"

--- a/pkg_files.c
+++ b/pkg_files.c
@@ -1,0 +1,316 @@
+/* $Id:$ */
+
+/*
+ * Copyright (c) 2009, 2010, 2011, 2012 The NetBSD Foundation, Inc.
+ * All rights reserved.
+ *
+ * This code is derived from software contributed to The NetBSD Foundation
+ * by Emile "iMil" Heitor <imil@NetBSD.org> .
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ *
+ */
+
+#include <regex.h>
+#include <zlib.h>
+#include "pkgin.h"
+
+#define PKG_FILES_GZ 0
+#define PKG_FILES_BZ2 1
+
+static const char *const files_exts[] = { "bz2", "gz", NULL };
+static const int files_kind { PKG_FILES_BZ2, PKG_FILES_GZ };
+
+static void
+pkg_files_dir(char *repo, char *dir, int dir_size)
+{
+	char	*esc, repo_dir[BUFSIZ];
+
+	snprintf(repo_dir, BUFSIZ, "%s", repo);
+
+        while ((esc = strpbrk(repo_dir, ":/")) != NULL) {
+		*esc = '_';
+	}
+
+	create_dir(PKG_FILES_CACHE);
+	snprintf(dir, dir_size, "%s/%s", PKG_FILES_CACHE, repo_dir);
+        create_dir(dir);
+} 
+
+/**
+ * Fetch remote pkg_files to local cache
+ */
+void
+fetch_pkg_files(char *cur_repo)
+{
+	/* from pkg_install/files/admin/audit.c */
+	FILE		*fp = NULL;
+	struct stat	st;
+	Dlfile		*file = NULL;
+	char		*decompressed_input;
+	size_t		decompressed_len;
+	time_t		files_mtime;
+	int		i;
+	char		**out, buf[BUFSIZ], repo_dir[BUFSIZ], buf_fs[BUFSIZ];
+
+	pkg_files_dir(cur_repo, repo_dir, BUFSIZ);
+
+	for (i = 0; files_exts[i] != NULL; i++) { /* try all extensions */
+		snprintf(buf, BUFSIZ, "%s/%s.%s", cur_repo, PKG_FILES, files_exts[i]);
+		snprintf(buf_fs, BUFSIZ, "%s/%s.%s", repo_dir, PKG_FILES, files_exts[i]);
+
+		if (!force_fetch && !force_update)
+			if (stat(buf_fs, &st) == 0)
+				files_mtime = st.st_mtime;
+		else
+			files_mtime = 0; /* 0 files_mtime == force reload */
+
+
+		if ((file = download_file(buf, &files_mtime)) != NULL)
+			break; /* pkg_files found and not up-to-date */
+
+		if (files_mtime < 0) /* pkg_files found, but up-to-date */
+			return;
+	}
+
+	if (file == NULL)
+		errx(EXIT_FAILURE, MSG_COULDNT_FETCH, buf);
+
+	umask(DEF_UMASK);
+	if ((fp = fopen(buf_fs, "w")) == NULL)
+		err(EXIT_FAILURE, MSG_ERR_OPEN, buf_fs);
+
+	fwrite(file->buf, file->size, 1, fp);
+	fclose(fp);
+
+	XFREE(file->buf);
+	XFREE(file);
+}
+
+void *
+open_pkg_files_gz(const char *path)
+{
+	void	*files;
+
+	if ((files = (void *) gzopen(path, "r")) == NULL) {
+		errx(1, "gzopen: %s: %s", path, strerror(errno));
+	}
+
+	return files;
+}
+
+void *
+open_pkg_files_bz2(const char *path)
+{
+	void	*files;
+
+	if ((files = (void *) BZ2_bzopen(path, "r")) == NULL) {
+		errx(1, "bzopen: %s: %s", path, strerror(errno));
+	}
+
+	return files;
+}
+
+void *
+open_pkg_files(const char *path, int kind)
+{
+	void	*files = NULL;
+
+	switch (kind) {
+		case PKG_FILES_GZ:
+			files = open_pkg_files_gz(path);
+		break;
+		case PKG_FILES_BZ2:
+			files = open_pkg_files_bz2(path);
+		break;
+		default:
+			errx(1, "unknown pkg_files kind");
+		break;
+	}
+
+	return files;
+}
+
+int
+read_pkg_files_gz(void *fd, char *buf, int size)
+{
+	gzFile		*files = (gzFile *) fd;
+	int		err;
+	const char	*err_str;
+	int		bytes_read;
+
+	if ((bytes_read = gzread(files, buf, size)) < size) {
+		if (gzeof(files)) {
+			bytes_read = 0;
+		} else {
+			err_str = gzerror(files, &err);
+
+			if (err) {
+				errx(1, "gzread error: %s", err_str);
+			}
+		}
+	}
+
+	return bytes_read;
+}
+
+int
+read_pkg_files_bz2(void *fd, char *buf, int size)
+{
+	BZFILE		*files = (BZFILE *) fd;
+	int		err;
+	const char	*err_str;
+	int		bytes_read;
+
+	if ((bytes_read = BZ_bzread(files, buf, size)) < size) {
+		err_str = BZ_bzerror(files, &err);
+
+		if (err == BZ_OK) {
+			bytes_read = 0;
+		} else {
+			errx(1, "bzread error: %s", err_str);
+		}
+	}
+
+	return bytes_read;
+}
+
+int
+read_pkg_files(void *files, int kind, char *buf, int buf_size)
+{
+	int	rc = 0;
+
+	switch (kind) {
+		case PKG_FILES_GZ:
+			rc = read_pkg_files_gz(files, buf, buf_size);
+		break;
+		case PKG_FILES_BZ2:
+			rc = read_pkg_files_bz2(files, buf, buf_size);
+		break;
+		default:
+			errx(1, "unknown pkg_files kind");
+		break;
+	}
+
+	return rc;
+}
+
+void
+close_pkg_files(void *files, int kind)
+{
+	switch (kind) {
+		case PKG_FILES_GZ:
+			gzclose((gzFile *) files);
+		break;
+		case PKG_FILES_BZ2:
+			BZ2_bzclose((BZFILE *) files);
+		break;
+		default:
+			errx(1, "unknown pkg_files kind");
+		break;
+	}
+}
+
+void
+search_pkg_file_lines(regex_t *re, char *buf, int buf_size)
+{
+	int	i, sz;
+	char	*sep = ": ";
+	char	*line, *pfile;
+
+	line = buf;
+	sz = 0;
+
+	for (i = 0; i < buf_size; i++) {
+		if (buf[i] != '\n') {
+			sz++;
+			continue;
+		}
+
+		buf[i] = '\0';
+
+		if ((pfile = strnstr(line, sep, sz)) == NULL) {
+			/* failure here is not expected */
+			return;
+		}
+
+		pfile += 2;
+
+		if (regexec(re, pfile, 0, NULL, 0) == 0) {
+			printf("%s\n", line);
+		}
+
+		line = &buf[i + 1];
+	}
+}
+
+int
+search_pkg_file(char *repo, const char *pattern)
+{
+	regex_t		re;
+	struct stat	st;
+	int		i, kind, rc, bytes_read, wanted;
+	char		eb[64], repo_dir[BUFSIZ], buf[BUFSIZ], *repo_file, *bytes;
+        int		gz_buf_size = BUFSIZ * 128;
+	char		*start, *end;
+	void		*files;
+
+	pkg_files_dir(repo, repo_dir, BUFSIZ);
+	repo_file = NULL;
+	kind = -1;
+
+	for (i = 0; files_exts[i] != NULL; i++) { /* try all extensions */
+		snprintf(buf, BUFSIZ, "%s/%s.%s", repo_dir, PKG_FILES, files_exts[i]);
+
+		if (stat(buf, &st) == 0) {
+			repo_file = buf;
+			kind = files_kinds[i];
+		}
+	}
+
+	if (repo_file == NULL) {
+		return 0;
+	}
+
+	if ((rc = regcomp(&re, pattern,
+		REG_EXTENDED|REG_NOSUB)) != 0) {
+		regerror(rc, &re, eb, sizeof(eb));
+		errx(1, "regcomp: %s: %s", pattern, eb);
+	}
+
+	files = open_pkg_files(buf, kind);
+
+	wanted = FBUFSIZ;
+	start = bytes;
+
+	while ((bytes_read = read_pkg_files(files, kind, bytes, wanted)) != 0) {
+		bytes[bytes_read] = '\0';
+
+		if ((end = strrchr(bytes, '\n')) != NULL) {
+			search_pkg_file_lines(&re, bytes, end - start + 1);
+		}	
+	}
+
+	close_pkg_files(files, kind);
+
+	return EXIT_SUCCESS;
+}

--- a/pkg_files.c
+++ b/pkg_files.c
@@ -305,10 +305,18 @@ search_pkg_file_in_repo(const char *repo, const char *pattern)
         buf_size = 0;
 	left_overs = 0;
 
-	while ((bytes_read = read_pkg_files(
+	for ( ; ; ) {
+		bytes_read = read_pkg_files(
 			files, kind,
-			bytes + left_overs, z_buf_size - left_overs)) != 0) {
-		bytes[bytes_read + left_overs] = '\0';
+			bytes + left_overs, z_buf_size - left_overs
+		);
+
+		if (bytes_read == 0) {
+			break;
+		}
+
+		bytes_read += left_overs;
+		bytes[bytes_read] = '\0';
 
 		if ((end = strrchr(bytes, '\n')) == NULL) {
 			/* failure not expected here */

--- a/pkg_files.c
+++ b/pkg_files.c
@@ -88,8 +88,10 @@ fetch_pkg_files(const char *cur_repo)
 		if ((file = download_file(buf, &files_mtime)) != NULL)
 			break; /* pkg_files found and not up-to-date */
 
-		if (files_mtime < 0) /* pkg_files found, but up-to-date */
+		if (files_mtime < 0) { /* pkg_files found, but up-to-date */
+			printf(MSG_PKG_FILES_IS_UP_TO_DATE, cur_repo);
 			return;
+		}
 	}
 
 	if (file == NULL)

--- a/pkg_files.c
+++ b/pkg_files.c
@@ -308,7 +308,7 @@ search_pkg_file_in_repo(const char *repo, const char *pattern)
 	while ((bytes_read = read_pkg_files(
 			files, kind,
 			bytes + left_overs, z_buf_size - left_overs)) != 0) {
-		bytes[bytes_read] = '\0';
+		bytes[bytes_read + left_overs] = '\0';
 
 		if ((end = strrchr(bytes, '\n')) == NULL) {
 			/* failure not expected here */

--- a/pkg_files.c
+++ b/pkg_files.c
@@ -325,7 +325,7 @@ search_pkg_file(const char *pattern)
 
 	/* loop through PKG_REPOS */
 	for (prepos = pkg_repos; *prepos != NULL; prepos++) {
-		search_pkg_file_in_repo(*prepos);
+		search_pkg_file_in_repo(*prepos, pattern);
 	}
 
 	return EXIT_SUCCESS;

--- a/pkgin.1
+++ b/pkgin.1
@@ -124,6 +124,9 @@ requires from others
 .Ar packages .
 .It Cm search Ar pattern
 Performs a regular expression search for a pattern in the repository.
+.It Cm search-file Ar pattern
+Performs a regular expression search for packages containing files
+matching pattern in the repository.
 .It Cm show-deps 
 Displays all direct dependencies
 .It Cm show-full-deps Ar package

--- a/pkgin.h
+++ b/pkgin.h
@@ -56,9 +56,11 @@
 #define PKG_INFO PKGTOOLS"/pkg_info"
 
 #define PKG_SUMMARY "pkg_summary"
+#define PKG_FILES "pkg_files"
 #define PKGIN_SQL_LOG PKGIN_DB"/sql.log"
 #define PKG_INSTALL_ERR_LOG PKGIN_DB"/pkg_install-err.log"
 #define PKGIN_CACHE PKGIN_DB"/cache"
+#define PKGIN_FILES_CACHE PKGIN_CACHE"/"PKG_FILES
 #define PKG_EXT ".tgz"
 #define PKGIN_CONF PKG_SYSCONFDIR"/pkgin"
 #define REPOS_FILE "repositories.conf"
@@ -115,6 +117,7 @@
 #define PKG_SHCAT_CMD 24
 #define PKG_SHPCAT_CMD 25
 #define PKG_SHALLCAT_CMD 26
+#define PKG_SRCHF_CMD 27
 #define PKG_GINTO_CMD 255
 
 #define PKG_EQUAL '='
@@ -265,6 +268,7 @@ void		pkg_keep(int, char **);
 int		fs_has_room(const char *, int64_t);
 uint64_t	fs_room(const char *);
 void		clean_cache(void);
+void		create_dir(void);
 void		create_dirs(void);
 char		*read_repos(void);
 /* pkg_str.c */
@@ -287,5 +291,8 @@ void		show_prov_req(const char *, const char *);
 void		show_pkg_info(char, char *);
 /* pkgindb.c */
 void		get_pkg_dbdir(void);
+/* pkg_files.c */
+void		fetch_pkg_files(char *url);
+int		search_pkg_file(const char *);
 
 #endif

--- a/pkgin.h
+++ b/pkgin.h
@@ -268,7 +268,7 @@ void		pkg_keep(int, char **);
 int		fs_has_room(const char *, int64_t);
 uint64_t	fs_room(const char *);
 void		clean_cache(void);
-void		create_dir(void);
+void		create_dir(const char *);
 void		create_dirs(void);
 char		*read_repos(void);
 /* pkg_str.c */
@@ -292,7 +292,7 @@ void		show_pkg_info(char, char *);
 /* pkgindb.c */
 void		get_pkg_dbdir(void);
 /* pkg_files.c */
-void		fetch_pkg_files(char *url);
-int		search_pkg_file(const char *);
+int		search_pkg_file(const char*);
+int		update_pkg_files(void);
 
 #endif

--- a/pkglist.c
+++ b/pkglist.c
@@ -30,8 +30,8 @@
  *
  */
 
-#include "pkgin.h"
 #include <regex.h>
+#include "pkgin.h"
 
 Plisthead	r_plisthead, l_plisthead;
 int		r_plistcounter, l_plistcounter;

--- a/summary.c
+++ b/summary.c
@@ -652,6 +652,7 @@ update_remotedb(void)
 
 	/* loop through PKG_REPOS */
 	for (prepos = pkg_repos; *prepos != NULL; prepos++) {
+		fetch_files(*prepos);
 
 		/* load remote pkg_summary */
 		if ((summary = fetch_summary(*prepos)) == NULL) {

--- a/summary.c
+++ b/summary.c
@@ -652,7 +652,6 @@ update_remotedb(void)
 
 	/* loop through PKG_REPOS */
 	for (prepos = pkg_repos; *prepos != NULL; prepos++) {
-		fetch_files(*prepos);
 
 		/* load remote pkg_summary */
 		if ((summary = fetch_summary(*prepos)) == NULL) {


### PR DESCRIPTION
Hi iMil,

while working on some project, I needed an `apt-file search foo.h` feature but to the best of my knowledge, it is not available for non-installed packages. So I decided to create one for pkgin.

Please note that it needs some support from `pkg_info`. I added a new `-Y` option to it that outputs what is needed for the `search-file` command. The modified pkg_info is available here:

https://github.com/yrmt/pkgsrc/commit/eed914709e8e9e691c03ca78bbe15af0b56038c9

What do you think about it ?