### PR TITLE
Add 'stats' or 'st' option to pkgin

### DIFF
--- a/cmd.h
+++ b/cmd.h
@@ -92,5 +92,7 @@ static struct command {
 	  PKG_SHPKGBDEFS_CMD },
 	{ "tonic", "to", "Gin Tonic recipe.",
 	  PKG_GINTO_CMD },
+        { "stats", "st", "Packages statistics.",
+          PKG_STATS_CMD },
 	{ NULL, NULL, NULL, 0 }
 };

--- a/main.c
+++ b/main.c
@@ -281,6 +281,9 @@ main(int argc, char *argv[])
 	case PKG_GINTO_CMD: /* Miod's request */
 		ginto();
 		break;
+        case PKG_STATS_CMD: /* show package statistics */
+                pkgindb_stats();
+                break;
 	default:
 		usage();
 		/* NOTREACHED */

--- a/messages.h
+++ b/messages.h
@@ -152,6 +152,13 @@ please re-run %s with a package name matching one of the following:\n"
 
 /* pkgindb.c */
 #define MSG_DELETE_DB_FAILED "Failed to delete database file %s\n"
+#define MSG_LOCAL_STAT_TITLE "Local package datadase:\n"
+#define MSG_LOCAL_PACKAGES "\tInstalled packages: %s\n"
+#define MSG_LOCAL_PKG_SIZE "\tDisk space occupied: %s\n\n"
+#define MSG_REMOTE_STAT_TITLE "Remote package database(s):\n"
+#define MSG_REMOTE_NB_REPOS "\tNumber of repositories: %d\n"
+#define MSG_REMOTE_PACKAGES "\tPackages available: %s\n"
+#define MSG_REMOTE_PKG_SIZE "\tTotal size of packages: %s\n"
 
 /* fsops.c */
 #define MSG_TRANS_FAILED "Failed to translate %s in repository config file"

--- a/pkgin.h
+++ b/pkgin.h
@@ -115,6 +115,7 @@
 #define PKG_SHCAT_CMD 24
 #define PKG_SHPCAT_CMD 25
 #define PKG_SHALLCAT_CMD 26
+#define PKG_STATS_CMD 27
 #define PKG_GINTO_CMD 255
 
 #define PKG_EQUAL '='

--- a/pkgindb.h
+++ b/pkgindb.h
@@ -91,6 +91,7 @@ int			pkg_db_mtime(void);
 void		repo_record(char **);
 time_t		pkg_sum_mtime(char *);
 void		pkgindb_reset(void);
+void            pkgindb_stats(void);
 
 #define PDB_OK 0
 #define PDB_ERR -1


### PR DESCRIPTION
to show package statistics like this:

─(master)──── ./pkgin st
Local package datadase:
    Installed packages: 488
    Disk space occupied: 2124M

Remote package database(s):
    Number of repositories: 1
    Packages available: 8225
    Total size of packages: 7921M
