### PR TITLE
joyent/pkgsrc#282: handle signature failures.

### DIFF
--- a/actions.c
+++ b/actions.c
@@ -159,6 +159,9 @@ analyse_pkglog(long int filepos)
 		/* Can't install dependency */
 		if (strstr(err_line, "an\'t install") != NULL)
 			err_count++;
+		/* unable to verify signature */
+		if (strstr(err_line, "unable to verify signature") != NULL)
+			err_count++;
 	}
 
 	fclose(err_ro);


### PR DESCRIPTION
Parse error log for pkg_add signature verification failures.