### PR TITLE
Ensure all remote repository entries are removed.

### DIFF
--- a/summary.c
+++ b/summary.c
@@ -778,12 +778,9 @@ cmp_repo_list(void *param, int argc, char **argv, char **colname)
 				match = 1;
 		if (match == 0) {
 			printf(MSG_CLEANING_DB_FROM_REPO, argv[i]);
+			delete_remote_tbl(sumsw[REMOTE_SUMMARY], argv[i]);
 			snprintf(query, BUFSIZ,
 			"DELETE FROM REPOS WHERE REPO_URL = '%s';", argv[i]);
-			pkgindb_doquery(query, NULL, NULL);
-			snprintf(query, BUFSIZ,
-			"DELETE FROM REMOTE_PKG WHERE REPOSITORY = '%s';",
-			argv[i]);
 			pkgindb_doquery(query, NULL, NULL);
 
 			force_fetch = 1;


### PR DESCRIPTION
This resolves a long-standing bug in pkgin when switching repository URLs.  To date the old entries have not been cleaned properly, resulting in a corrupt database.  An example session to show the behaviour is below.

* Start with a clean 2015Q1 repository and show what would happen if we try to install `coreutils`:

```console
$ pkgin up
reading local summary...
processing local summary...
updating database: 100%
pkg_summary.bz2                                                   100% 1997KB   2.0MB/s   2.0MB/s   00:01
processing remote summary (http://pkgsrc.joyent.com/packages/SmartOS/2015Q1/i386/All)...
updating database: 100%

$ pkgin in coreutils
calculating dependencies... done.

nothing to upgrade.
1 packages to be installed (7133K to download, 17M to install):

coreutils-8.22nb2

proceed ? [Y/n] n
```

* Save the pkgin.db for restoring later.

```console
$ cp /var/db/pkgin/pkgin.db save.db
```

* Update the repository to 2015Q2 and again attempt to install coreutils:

```console
$ /usr/perl5/bin/perl -pi -e 's,2015Q1,2015Q2,g' /opt/local/etc/pkgin/repositories.conf

$ pkgin up
cleaning database from http://pkgsrc.joyent.com/packages/SmartOS/2015Q1/i386/All entries...
pkg_summary.bz2                                                   100% 2082KB   2.0MB/s   2.0MB/s   00:01
processing remote summary (http://pkgsrc.joyent.com/packages/SmartOS/2015Q2/i386/All)...
updating database: 100%

$ pkgin in coreutils
calculating dependencies... done.
lzmalib-0.0.1 (to be installed) conflicts with installed package xz-5.2.1.
proceed ? [y/N] y

nothing to upgrade.
1874 packages to be installed (2168M to download, 7590M to install):

p5-HTML-Prototype-1.48nb7 p5-String-Formatter-0.102084nb1 p5-Spreadsheet-WriteExcel-2.37nb6
[1800+ entries removed..]

proceed ? [Y/n] n
```

Clearly this is broken, due to all the database identifiers being incorrect and pointing to the wrong entries.

Now try the same with a patched pkgin:

```console
$ cp save.db /var/db/pkgin/pkgin.db

$ ./pkgin up
cleaning database from http://pkgsrc.joyent.com/packages/SmartOS/2015Q1/i386/All entries...
pkg_summary.bz2                                                   100% 2082KB   2.0MB/s   2.0MB/s   00:00
processing remote summary (http://pkgsrc.joyent.com/packages/SmartOS/2015Q2/i386/All)...
updating database: 100%

$ ./pkgin in coreutils
calculating dependencies... done.

nothing to upgrade.
1 packages to be installed (7237K to download, 18M to install):

coreutils-8.23nb1

proceed ? [Y/n] n
```

We now see the expected output with the updated coreutils package available from the newer repository.