### PR TITLE
Update database if remote repository list changed.

### DIFF
--- a/pkgin.h
+++ b/pkgin.h
@@ -230,7 +230,7 @@ Dlfile		*download_file(char *, time_t *);
 /* summary.c */
 int		update_db(int, char **);
 void		split_repos(void);
-void		chk_repo_list(void);
+int		chk_repo_list(void);
 /* sqlite_callbacks.c */
 int		pdb_rec_list(void *, int, char **, char **);
 int		pdb_rec_depends(void *, int, char **, char **);

--- a/summary.c
+++ b/summary.c
@@ -793,8 +793,10 @@ cmp_repo_list(void *param, int argc, char **argv, char **colname)
 	return PDB_OK;
 }
 
-void
+int
 chk_repo_list()
 {
 	pkgindb_doquery("SELECT REPO_URL FROM REPOS;", cmp_repo_list, NULL);
+
+	return force_fetch;
 }


### PR DESCRIPTION
This commit ensures that if `repositories.conf` is changed and a `pkgin install` operation is requested straight after, the remote summaries are updated first and the operation will compete successfully rather than failing due to empty remote summaries.

Here is the current behaviour on SmartOS with 2015Q1 repository changing to 2015Q2:

```console
$ pkgin up
reading local summary...
processing local summary...
updating database: 100%
pkg_summary.bz2                                                     100% 1997KB   2.0MB/s   2.0MB/s   00:00
processing remote summary (http://pkgsrc.joyent.com/packages/SmartOS/2015Q1/i386/All)...
updating database: 100%

$ /usr/perl5/bin/perl -pi -e 's,2015Q1,2015Q2,g' /opt/local/etc/pkgin/repositories.conf

$ pkgin in coreutils
cleaning database from http://pkgsrc.joyent.com/packages/SmartOS/2015Q1/i386/All entries...
empty available packages list
nothing to do.
```

After applying this pull request the behaviour changes to:

```console
$ pkgin up
reading local summary...
processing local summary...
updating database: 100%
pkg_summary.bz2                                                     100% 1997KB   2.0MB/s   2.0MB/s   00:00
processing remote summary (http://pkgsrc.joyent.com/packages/SmartOS/2015Q1/i386/All)...
updating database: 100%

$ /usr/perl5/bin/perl -pi -e 's,2015Q1,2015Q2,g' /opt/local/etc/pkgin/repositories.conf

$ ./pkgin in coreutils
cleaning database from http://pkgsrc.joyent.com/packages/SmartOS/2015Q1/i386/All entries...
pkg_summary.bz2                                                     100% 2082KB   2.0MB/s   2.0MB/s   00:01
processing remote summary (http://pkgsrc.joyent.com/packages/SmartOS/2015Q2/i386/All)...
updating database: 100%
calculating dependencies... done.
lzmalib-0.0.1 (to be installed) conflicts with installed package xz-5.2.1.
proceed ? [y/N]
```

We are now hitting the bugs fixed by NetBSDfr/pkgin#52, but this is enough to show that the behaviour is now changed to do what the user would likely expect, and with NetBSDfr/pkgin#52 applied would result in coreutils from 2015Q2 being installed.