### PR TITLE
Disable upgrade database prompt.

### DIFF
--- a/pkgindb.c
+++ b/pkgindb.c
@@ -161,6 +161,7 @@ upgrade_database()
 {
 	if (pkgindb_doquery(COMPAT_CHECK,
 			pkgindb_simple_callback, NULL) == PDB_ERR) {
+#ifdef notyet
 		/*
 		 * COMPAT_CHECK query leads to an error for an
 		 * incompatible database
@@ -168,6 +169,7 @@ upgrade_database()
 		printf(MSG_DATABASE_NOT_COMPAT);
 		if (!check_yesno(DEFAULT_YES))
 			exit(EXIT_FAILURE);
+#endif
 
 		pkgindb_reset();
 


### PR DESCRIPTION
At present there is no proper upgrade test, it merely checks whether
there are any entries in the database.  As this will be false on first
update, we don't want to have to confirm when we clearly need to perform
an update regardless.

Marked as '#ifdef notyet' so that if in the future the database format
does change we can write a query to detect that situation and re-enable
the check (though arguably we'd always want to upgrade anyway).

We've been running with this for many years in SmartOS and OSX
packages sets.