### PR TITLE
Only display parsable list output when -p is used.

### DIFF
--- a/main.c
+++ b/main.c
@@ -40,7 +40,7 @@ static void	missing_param(int, int, const char *);
 static void	ginto(void);
 
 uint8_t		yesflag = 0, noflag = 0, force_update = 0, force_reinstall = 0;
-uint8_t		verbosity = 0, package_version = 0, parsable = 0;
+uint8_t		verbosity = 0, package_version = 0, parsable = 0, pflag = 0;
 char		lslimit = '\0';
 FILE  		*tracefp = NULL;
 
@@ -106,6 +106,7 @@ main(int argc, char *argv[])
 			break;
 		case 'p':
 			parsable = 1;
+			pflag = 1;
 			break;
 		default:
 			usage();

--- a/pkgin.h
+++ b/pkgin.h
@@ -212,6 +212,7 @@ extern uint8_t		verbosity;
 extern uint8_t		package_version;
 extern uint8_t		pi_upgrade; /* pkg_install upgrade */
 extern uint8_t		parsable;
+extern uint8_t		pflag;
 extern int		r_plistcounter;
 extern int		l_plistcounter;
 extern char		*env_repos;

--- a/pkglist.c
+++ b/pkglist.c
@@ -237,7 +237,7 @@ pkg_is_installed(Plisthead *plisthead, Pkglist *pkg)
 static void
 setfmt(char *sfmt, char *pfmt)
 {
-	if (parsable) {
+	if (pflag) {
 		strncpy(sfmt, "%s;%c", 6); /* snprintf(outpkg) */
 		strncpy(pfmt, "%s;%s\n", 7); /* final printf */
 	} else {


### PR DESCRIPTION
Previously list output would differ depending on whether the output was
a tty or not, causing issues with various automated tools.

Fixes NetBSDfr/pkgin#46.