### PR TITLE
Check for strsep(3)

### DIFF
--- a/config.h.in
+++ b/config.h.in
@@ -129,6 +129,9 @@
 /* Define to 1 if you have the `strrchr' function. */
 #undef HAVE_STRRCHR
 
+/* Define to 1 if you have the `strsep' function. */
+#undef HAVE_STRSEP
+
 /* Define to 1 if you have the `strstr' function. */
 #undef HAVE_STRSTR
 

--- a/configure
+++ b/configure
@@ -4307,7 +4307,7 @@ if test "${with_pkginstall+set}" = set; then :
 fi
 
 
-for ac_func in dup2 getcwd localeconv memmove memset mkdir putenv regcomp rmdir setenv strcasecmp strchr strcspn strdup strncasecmp strpbrk strrchr strstr strtol freopen tcgetpgrp
+for ac_func in dup2 getcwd localeconv memmove memset mkdir putenv regcomp rmdir setenv strcasecmp strchr strcspn strdup strncasecmp strpbrk strrchr strstr strtol freopen tcgetpgrp strsep
 do :
   as_ac_var=`$as_echo "ac_cv_func_$ac_func" | $as_tr_sh`
 ac_fn_c_check_func "$LINENO" "$ac_func" "$as_ac_var"

--- a/configure.ac
+++ b/configure.ac
@@ -32,7 +32,7 @@ AC_ARG_WITH(pkginstall,
 	,
 )
 
-AC_CHECK_FUNCS([dup2 getcwd localeconv memmove memset mkdir putenv regcomp rmdir setenv strcasecmp strchr strcspn strdup strncasecmp strpbrk strrchr strstr strtol freopen tcgetpgrp])
+AC_CHECK_FUNCS([dup2 getcwd localeconv memmove memset mkdir putenv regcomp rmdir setenv strcasecmp strchr strcspn strdup strncasecmp strpbrk strrchr strstr strtol freopen tcgetpgrp strsep])
 
 AC_CHECK_FUNC([pthread_create],,
 	AC_CHECK_LIB(pthread, pthread_create,,


### PR DESCRIPTION
strsep(3) is defined in nbcompat/string.h if nbcompat is installed,
guarded by a if !HAVE_STRSEP block.

On platforms where strsep(3) itself is a macro, rather than just shadow
the definition, this leads to a compiler error at configure time.

Also ran `autoreconf` to generate `config.h.in` and `configure`
