### PR TITLE
Exit directly when nothing is to be done

### DIFF
--- a/actions.c
+++ b/actions.c
@@ -610,6 +610,9 @@ pkgin_install(char **opkgargs, int do_inst)
 		printf("%d to refresh, %d to upgrade, %d to install\n",
 		    refreshnum, upgradenum, installnum);
 		printf("%s to download, %s to install\n", h_fsize, h_psize);
+
+		if (refreshnum == 0 && upgradenum == 0 && installnum == 0)
+			exit(rc);
 	} else {
 		printf("%d package%s to download:\n%s\n", downloadnum,
 		    (downloadnum == 1) ? "" : "s", todownload);


### PR DESCRIPTION
Just today I have run into this situation:
```shell-session
# pkgin fug
calculating dependencies...done.
/usr/lib/libwind.so.1, needed by curl-7.63.0nb1 is not present in this system.
/usr/lib/libssl.so.12, needed by curl-7.63.0nb1 is not present in this system.
/usr/lib/libroken.so.20, needed by curl-7.63.0nb1 is not present in this system.
/usr/lib/libkrb5.so.27, needed by curl-7.63.0nb1 is not present in this system.
/usr/lib/libhx509.so.6, needed by curl-7.63.0nb1 is not present in this system.
/usr/lib/libheimntlm.so.5, needed by curl-7.63.0nb1 is not present in this system.
/usr/lib/libheimbase.so.2, needed by curl-7.63.0nb1 is not present in this system.
/usr/lib/libgssapi.so.11, needed by curl-7.63.0nb1 is not present in this system.
/usr/lib/libcrypto.so.12, needed by curl-7.63.0nb1 is not present in this system.
/usr/lib/libcom_err.so.8, needed by curl-7.63.0nb1 is not present in this system.
/usr/lib/libasn1.so.10, needed by curl-7.63.0nb1 is not present in this system.
/usr/lib/libstdc++.so.8, needed by gmp-6.1.2 is not present in this system.
/usr/lib/libssl.so.12, needed by ircd-hybrid-7.2.3nb12 is not present in this system.
/usr/lib/libcrypto.so.12, needed by ircd-hybrid-7.2.3nb12 is not present in this system.
/usr/lib/libssl.so.12, needed by irssi-1.1.1nb1 is not present in this system.
/usr/lib/libcrypto.so.12, needed by irssi-1.1.1nb1 is not present in this system.
/usr/lib/libstdc++.so.8, needed by pcre-8.42 is not present in this system.
/usr/lib/libssl.so.12, needed by pkg_install-20180425 is not present in this system.
/usr/lib/liblzma.so.2, needed by pkg_install-20180425 is not present in this system.
/usr/lib/libcrypto.so.12, needed by pkg_install-20180425 is not present in this system.
/usr/lib/libarchive.so.4, needed by pkg_install-20180425 is not present in this system.
/usr/lib/libssl.so.12, needed by pkgin-0.11.6nb1 is not present in this system.
/usr/lib/liblzma.so.2, needed by pkgin-0.11.6nb1 is not present in this system.
/usr/lib/libcrypto.so.12, needed by pkgin-0.11.6nb1 is not present in this system.
/usr/lib/libarchive.so.4, needed by pkgin-0.11.6nb1 is not present in this system.
/usr/lib/libssl.so.12, needed by postfix-3.3.2 is not present in this system.
/usr/lib/libcrypto.so.12, needed by postfix-3.3.2 is not present in this system.
/usr/lib/libssl.so.12, needed by python27-2.7.15nb1 is not present in this system.
/usr/lib/libcrypto.so.12, needed by python27-2.7.15nb1 is not present in this system.

0 to refresh, 0 to upgrade, 0 to install
26M to download, -486K to install
the following packages have unmet requirements:   curl-7.63.0nb1 gmp-6.1.2 ircd-hybrid-7.2.3nb12 irssi-1.1.1nb1 pcre-8.42 pkg_install-20180425 pkgin-0.11.6nb1 postfix-3.3.2 python27-2.7.15nb1


proceed ? [Y/n]```

This was in the middle of a partial upgrade. When "proceeding" (pressing enter) pkgin simply did nothing. In such a scenario it does not make sense to ask; this patch should effectively do that.