### PR TITLE
Flush yes/no prompt before reading response

### DIFF
--- a/tools.c
+++ b/tools.c
@@ -205,6 +205,7 @@ check_yesno(uint8_t default_answer)
 		printf(MSG_PROCEED_YES);
 	else
 		printf(MSG_PROCEED_NO);
+	fflush(stdout);
 
 	c = tolower(getchar());
 	


### PR DESCRIPTION
musl libc does not flush output streams before reading input, so
the prompt does not get printed unless it is flushed explicitly.