### PR TITLE
Set fetchTimeout in main to fix gcc 10 build error

### DIFF
--- a/download.c
+++ b/download.c
@@ -30,7 +30,6 @@
 #include "pkgin.h"
 #include "external/progressmeter.h"
 
-int	fetchTimeout = 15; /* wait 15 seconds before timeout */
 size_t	fetch_buffer = 1024;
 
 /*

--- a/main.c
+++ b/main.c
@@ -55,6 +55,9 @@ main(int argc, char *argv[])
 	/* Default to not doing \r printouts if we don't send to a tty */
 	parsable = !isatty(fileno(stdout));
 
+	/* Wait 15 seconds before timeout */
+	fetchTimeout = 15;
+
 	while ((ch = getopt(argc, argv, "dhyfFPvVl:nc:t:p")) != -1) {
 		switch (ch) {
 		case 'f':


### PR DESCRIPTION
gcc 10 enables -fno-common by default, so duplicate definitions of
globals result in build errors.

To fix this, change fetchTimeout in main rather than making a
separate definition.