### PR TITLE
Fix NPE segfault when "verbose" is enabled

### DIFF
--- a/actions.c
+++ b/actions.c
@@ -204,9 +204,10 @@ log_tag(const char *fmt, ...)
 	(void)strftime(now_date, DATELEN, "%b %d %H:%M:%S", &tim);
 
 	printf("%s", log_action);
-	fprintf(err_fp, "---%s: %s", now_date, log_action);
-	fflush(err_fp);
-	
+	if (!verbosity) {
+		fprintf(err_fp, "---%s: %s", now_date, log_action);
+		fflush(err_fp);
+	}
 }
 
 static void


### PR DESCRIPTION
Prior to revision b6068265, log_tag() was only ever invoked when err_fp
was guaranteed to be assigned. After that revision, it could be called
with err_fp being null. Carry some of the old "!verbose" logic into
log_tag() to address this.