### PR TITLE
Increase website text size

### DIFF
--- a/htdocs/global.css
+++ b/htdocs/global.css
@@ -4,8 +4,6 @@ body {
   background-color: #ffffff;
   color: #000000;
   font-family: Tahoma, sans-serif;
-  font-size: small;
-  line-height: 1.3em;
   margin: 0;
   padding: 0;
   background: url(/gfx/pkgin-icon-new.png) no-repeat;


### PR DESCRIPTION
I have always found the text on the website quite small. This change to the style sheet removes the small text size setting as well as the line-height setting (the default line-heights looked better to me -- they are not that different).
