### PR TITLE
Initialize downloadhead in pkgin_install

### DIFF
--- a/actions.c
+++ b/actions.c
@@ -417,7 +417,7 @@ pkgin_install(char **opkgargs, int do_inst, int upgrade)
 	size_t		len;
 	ssize_t		llen;
 	Pkglist		*pkg;
-	Plisthead	*impacthead, *downloadhead, *installhead = NULL;
+	Plisthead	*impacthead, *downloadhead = NULL, *installhead = NULL;
 	char		**pkgargs, *p;
 	char		*toinstall = NULL, *toupgrade = NULL;
 	char		*torefresh = NULL, *todownload = NULL;


### PR DESCRIPTION
When cancelling out of an attempted install with conflicts, pkgin_install jumps to installend before downloadhead has a chance to be initialized. This causes a segfault within free_pkglist (at least, in NetBSD 9.99.73) as the lists are being cleaned up. Example:
```
# pkgin install rust
calculating dependencies...done.
rust-1.45.2nb2 (to be installed) conflicts with installed package rust-bin-1.46.0.
proceed ? [y/N] n
Memory fault (core dumped)
```

Initializing downloadhead as NULL at the start of pkgin_install resolves this.