### PR TITLE
Use sysctl hw.machine_arch to determine processor type on NetBSD

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -183,6 +183,7 @@ AC_CHECK_FUNC([humanize_number],
 )
 AC_CHECK_HEADERS([util.h bsd/libutil.h libutil.h])
 AC_CHECK_HEADERS([sys/termios.h termios.h])
+AC_CHECK_HEADERS([sys/sysctl.h])
 #
 # Tests for library functions that may exist outside of libc.
 #

--- a/tools.c
+++ b/tools.c
@@ -120,6 +120,18 @@ getosarch(void)
 {
 	char			*ret;
 	struct utsname	un;
+#if defined(HAVE_SYS_SYSCTL_H) && defined(HW_MACHINE_ARCH)
+	char	machine_arch[32];
+	int	mib[2];
+	size_t	len;
+
+	len = sizeof(machine_arch);
+	mib[0] = CTL_HW;
+	mib[1] = HW_MACHINE_ARCH;
+
+	if (sysctl(mib, 2, machine_arch, &len, NULL, 0) != -1)
+		return xstrdup(machine_arch);
+#endif
 
 	memset(&un, 0, sizeof(un));
 	if (uname(&un) < 0)

--- a/tools.h
+++ b/tools.h
@@ -52,6 +52,10 @@
 #include <util.h>
 #endif
 
+#if defined(HAVE_SYS_SYSCTL_H)
+#include <sys/sysctl.h>
+#endif
+
 #include "external/lib.h"
 
 #ifndef HN_AUTOSCALE


### PR DESCRIPTION
`hw.machine_arch` is more useful for finding the correct package repository and matches the `MACHINE_ARCH` variable in pkgsrc.

e.g., on aarch64:

`uname -m` is "evbarm"
`uname -p` (`sysctl hw.machine_arch`) is "aarch64"

on amd64:

`uname -m` is "amd64"
`uname -p` (`sysctl hw.machine_arch`) is "x86_64"

This also matches the default setting for PKG_PATH on NetBSD which uses `uname -p` rather than `uname -m`.