### PR TITLE
Change IRC network to Libera in index.html

### DIFF
--- a/htdocs/index.html
+++ b/htdocs/index.html
@@ -197,7 +197,7 @@ $ cvs -z3 -d:pserver:anonymous@cvs.pkgin.net:/cvsroot/pkgin co -P pkgin</pre>
 			<h3>Contact</h3>
 
 			<p>
-			Please do not hesitate to contact me, either by mail at <a href="mailto:imil@NetBSD.org">imil@NetBSD.org</a> or <i>iMil</i> on the <a href="http://freenode.net/">Freenode</a> IRC Network.
+			Please do not hesitate to contact me, either by mail at <a href="mailto:imil@NetBSD.org">imil@NetBSD.org</a> or <i>iMil</i> on the <a href="https://libera.chat/">Libera.Chat</a> IRC Network.
 			</p>
 
 			<p>


### PR DESCRIPTION
With the recent move to Libera.chat (see http://blog.netbsd.org/tnf/entry/public_netbsd_irc_channels_moved) the official project channels are no longer hosted on Freenode.