### PR TITLE
Fixes #114, copy argv when pkg in wo globs can be expanded by impact.c

### DIFF
--- a/actions.c
+++ b/actions.c
@@ -410,7 +410,7 @@ pkgin_install(char **pkgargs, int do_inst, int upgrade)
 	FILE		*fp;
 	int		installnum = 0, upgradenum = 0, removenum = 0;
 	int		refreshnum = 0, downloadnum = 0;
-	int		i, rc = EXIT_SUCCESS;
+	int		rc = EXIT_SUCCESS;
 	int		privsreqd = PRIVS_PKGINDB;
 	uint64_t	free_space;
 	int64_t		file_size = 0, size_pkg = 0;
@@ -418,7 +418,6 @@ pkgin_install(char **pkgargs, int do_inst, int upgrade)
 	ssize_t		llen;
 	Pkglist		*pkg;
 	Plisthead	*impacthead, *downloadhead = NULL, *installhead = NULL;
-	char		**kpkgargs;
 	char		*p;
 	char		*toinstall = NULL, *toupgrade = NULL;
 	char		*torefresh = NULL, *todownload = NULL;
@@ -438,18 +437,8 @@ pkgin_install(char **pkgargs, int do_inst, int upgrade)
 	if (!have_privs(privsreqd))
 		errx(EXIT_FAILURE, MSG_DONT_HAVE_RIGHTS);
 
-	/*
-	 * copy const argv to a modifiable array to expand globs in
-	 * pkg_impact, https://github.com/NetBSDfr/pkgin/issues/114
-	 * */
-	for (i = 0; pkgargs[i] != NULL; i++); /* args number */
-	kpkgargs = xmalloc(i*sizeof(char *));
-	for (i = 0; pkgargs[i] != NULL; i++) {
-		kpkgargs[i] = xstrdup(pkgargs[i]);
-	}
-
 	/* full impact list */
-	if ((impacthead = pkg_impact(kpkgargs, &rc)) == NULL) {
+	if ((impacthead = pkg_impact(pkgargs, &rc)) == NULL) {
 		printf(MSG_NOTHING_TO_DO);
 		return rc;
 	}
@@ -688,7 +677,7 @@ pkgin_install(char **pkgargs, int do_inst, int upgrade)
 
 	/* pure install, not called by pkgin_upgrade */
 	if (!upgrade)
-		(void)update_db(LOCAL_SUMMARY, kpkgargs, 1);
+		(void)update_db(LOCAL_SUMMARY, pkgargs, 1);
 
 installend:
 
@@ -697,7 +686,7 @@ installend:
 	XFREE(unmet_reqs);
 	free_pkglist(&impacthead);
 	free_pkglist(&downloadhead);
-	free_list(kpkgargs);
+	free_list(pkgargs);
 	/*
 	 * installhead may be NULL, for example if trying to install a package
 	 * that conflicts.

--- a/impact.c
+++ b/impact.c
@@ -390,6 +390,8 @@ pkg_impact(char **pkgargs, int *rc)
 		}
 
 		TRACE("[+]-impact for %s\n", pkgname);
+		/* copy real package name back to pkgargs */
+		*ppkgargs = xstrdup(pkgname);
 
 		if (istty) {
 			tmpicon = *icon++;

--- a/main.c
+++ b/main.c
@@ -34,6 +34,7 @@
 static void	usage(int);
 static int	find_cmd(const char *);
 static void	missing_param(int, int, const char *);
+static char	**mkpkgargs(char **);
 static void	ginto(void);
 
 uint8_t		yesflag = 0, noflag = 0;
@@ -212,7 +213,7 @@ main(int argc, char *argv[])
 		break;
 	case PKG_INST_CMD: /* install a package and its dependencies */
 		missing_param(argc, 2, MSG_PKG_ARGS_INST);
-		rc = pkgin_install(&argv[1], do_inst, 0);
+		rc = pkgin_install(mkpkgargs(&argv[1]), do_inst, 0);
 		break;
 	/*
 	 * Historically there was a distinction between "upgrade" (only upgrade
@@ -335,6 +336,24 @@ find_cmd(const char *arg)
 	}
 
 	return -1;
+}
+
+/*
+ * copy const argv to a modifiable array to expand globs in
+ * pkg_impact, https://github.com/NetBSDfr/pkgin/issues/114
+ */
+static char **
+mkpkgargs(char **args)
+{
+	int i;
+	char **pkgargs;
+
+	for (i = 0; args[i] != NULL; i++); /* args number */
+	pkgargs = xmalloc(i*sizeof(char *));
+	for (i = 0; args[i] != NULL; i++) {
+		pkgargs[i] = xstrdup(args[i]);
+	}
+	return pkgargs;
 }
 
 __attribute__((noreturn))


### PR DESCRIPTION
`pkgargs` is originally a pointer to `&argv[1]` (list of packages or _globs_ to be installed); turns out this list is passed as-is to `update_db`, which in turn calls `update_localdb` and finally `pkg_keep` which will fails because it does not expand  _globs_. One simple fix is to let `pkg_impact` modify `pkgargs` to replace the list full packages names.