### PR TITLE
Fix the formatting of the list command in man pages

### DIFF
--- a/pkgin.1.in
+++ b/pkgin.1.in
@@ -94,7 +94,7 @@ A
 package is equivalent to a non-automatic package in
 .Xr pkgsrc 7
 terminology.
-.Ic list
+.It Cm list
 Lists all packages installed locally on a system.
 If the
 .Fl l


### PR DESCRIPTION
The explanations of the `list` command squashed into the `keep` command, and this patch fixes it.

![pkgin(1)](https://user-images.githubusercontent.com/10341686/143440375-48f097b3-144b-43d4-98bd-45ce3936bd43.png)
