### PR TITLE
Add flags for limiting libfetch to IPv4 or IPv6

### DIFF
--- a/download.c
+++ b/download.c
@@ -30,6 +30,8 @@
 #include "pkgin.h"
 #include "external/progressmeter.h"
 
+extern char fetchflags[3];
+
 /*
  * Open a pkg_summary and if newer than local return an open libfetch
  * connection to it.
@@ -44,7 +46,7 @@ sum_open(char *str_url, time_t *db_mtime)
 
 	url = fetchParseURL(str_url);
 
-	if (url == NULL || (f = fetchXGet(url, &st, "")) == NULL)
+	if (url == NULL || (f = fetchXGet(url, &st, fetchflags)) == NULL)
 		goto nofetch;
 
 	if (st.size == -1) { /* could not obtain file size */
@@ -171,7 +173,7 @@ download_pkg(char *pkg_url, FILE *fp)
 	if ((url = fetchParseURL(pkg_url)) == NULL)
 		errx(EXIT_FAILURE, "%s: parse failure", pkg_url);
 
-	if ((f = fetchXGet(url, &st, "")) == NULL) {
+	if ((f = fetchXGet(url, &st, fetchflags)) == NULL) {
 		fprintf(stderr, "download error: %s %s\n", pkg_url,
 		    fetchLastErrString);
 		return -1;

--- a/main.c
+++ b/main.c
@@ -65,7 +65,7 @@ main(int argc, char *argv[])
 			v4flag = 1;
 			break;
 		case '6':
-			v4flag = 1;
+			v6flag = 1;
 			break;
 		case 'f':
 			force_update = 1;

--- a/main.c
+++ b/main.c
@@ -40,6 +40,7 @@ static void	ginto(void);
 uint8_t		yesflag = 0, noflag = 0;
 uint8_t		verbosity = 0, package_version = 0, parsable = 0, pflag = 0;
 char		lslimit = '\0';
+char		fetchflags[3] = { 0, 0, 0 };
 FILE  		*tracefp = NULL;
 
 int
@@ -51,14 +52,21 @@ main(int argc, char *argv[])
 	int		force_update = 0;
 	char		**pkgargs = NULL;
 	const char	*chrootpath = NULL;
+	int		ffi = 0;
 
 	setprogname("pkgin");
 
 	/* Default to not doing \r printouts if we don't send to a tty */
 	parsable = !isatty(fileno(stdout));
 
-	while ((ch = getopt(argc, argv, "dhyfFPvVl:nc:t:p")) != -1) {
+	while ((ch = getopt(argc, argv, "46dhyfFPvVl:nc:t:p")) != -1) {
 		switch (ch) {
+		case '4':
+			fetchflags[ffi++] = '4';
+			break;
+		case '6':
+			fetchflags[ffi++] = '6';
+			break;
 		case 'f':
 			force_update = 1;
 			break;
@@ -368,7 +376,7 @@ usage(int status)
 	int i;
 
 	fprintf((status) ? stderr : stdout,
-	    "Usage: pkgin [-cdfhlnPtvVy] command [package ...]\n\n"
+	    "Usage: pkgin [-46cdfhlnPtvVy] command [package ...]\n\n"
 	    "Commands and shortcuts:\n");
 
 	for (i = 0; cmd[i].name != NULL; i++) {

--- a/main.c
+++ b/main.c
@@ -52,7 +52,7 @@ main(int argc, char *argv[])
 	int		force_update = 0;
 	char		**pkgargs = NULL;
 	const char	*chrootpath = NULL;
-	int		ffi = 0;
+	int		v4flag = 0, v6flag = 0, ffi = 0;
 
 	setprogname("pkgin");
 
@@ -62,10 +62,10 @@ main(int argc, char *argv[])
 	while ((ch = getopt(argc, argv, "46dhyfFPvVl:nc:t:p")) != -1) {
 		switch (ch) {
 		case '4':
-			fetchflags[ffi++] = '4';
+			v4flag = 1;
 			break;
 		case '6':
-			fetchflags[ffi++] = '6';
+			v4flag = 1;
 			break;
 		case 'f':
 			force_update = 1;
@@ -133,6 +133,14 @@ main(int argc, char *argv[])
 
 		if (chdir("/") == -1)
 			errx(-1, MSG_CHDIR_FAILED);
+	}
+
+	if (v4flag) {
+		fetchflags[ffi++] = '4';
+	}
+
+	if (v6flag) {
+		fetchflags[ffi++] = '6';
 	}
 
 	/* Configure pkg_install */

--- a/pkgin.1.in
+++ b/pkgin.1.in
@@ -6,7 +6,7 @@
 .Nd pkgsrc binary package manager
 .Sh SYNOPSIS
 .Nm
-.Op Fl dfhnPpVvy
+.Op Fl 46dfhnPpVvy
 .Op Fl c Ar chroot_path
 .Op Fl l Ar limit_chars
 .Op Fl t Ar log_file
@@ -24,6 +24,14 @@ installing, upgrading, removing, and querying available packages.
 .Sh OPTIONS
 The following command line arguments are supported:
 .Bl -tag -width 15n -offset 6n
+.It Fl 4
+Forces
+.B pkgin
+to only use IPv4 addresses.
+.It Fl 6
+Forces
+.B pkgin
+to only use IPv6 addresses.
 .It Fl c Ar chroot_path
 Enable chrooting
 .Nm


### PR DESCRIPTION
This PR adds the usual -4 and -6 flags to pkgin so that I can avoid problems with fastly breaking over ipv6 (for me)