### PR TITLE
Require valid certs for https:// repositories.

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ pkgin(1) -- A tool to manage pkgsrc binary packages.
 
 ## SYNOPSIS
 
-`pkgin` [`-dfFhpPvVyn`] [`-l` _limit_chars_] [`-c` _chroot_path_] [`-t` _log_file_] _command_ [package ...]
+`pkgin` [`-dfFhipPvVyn`] [`-l` _limit_chars_] [`-c` _chroot_path_] [`-t` _log_file_] _command_ [package ...]
 
 ## DESCRIPTION
 
@@ -27,6 +27,10 @@ The following command line arguments are supported:
 
   * `-h`:
     Displays help for the command
+
+  * `-i`:
+    Allow insecure downloads: bypass HTTPS certificate validation,
+    allow HTTPS to redirect to HTTP/FTP
 
   * `-l` _limit_chars_:
     Only include the packages with the specified [STATUS FLAGS][]

--- a/main.c
+++ b/main.c
@@ -39,8 +39,10 @@ static void	ginto(void);
 
 uint8_t		yesflag = 0, noflag = 0;
 uint8_t		verbosity = 0, package_version = 0, parsable = 0, pflag = 0;
+uint8_t		insecure_transport = 0;
 char		lslimit = '\0';
-char		fetchflags[4] = { 0, 0, 0, 0 };
+char		insecurefetchflags[5] = { 0, 0, 0, 0, 0 };
+char		fetchflags[6] = { 0, 0, 0, 0, 0, 0 };
 FILE  		*tracefp = NULL;
 
 int
@@ -59,13 +61,16 @@ main(int argc, char *argv[])
 	/* Default to not doing \r printouts if we don't send to a tty */
 	parsable = !isatty(fileno(stdout));
 
-	while ((ch = getopt(argc, argv, "46dhyfFPvVl:nc:t:p")) != -1) {
+	while ((ch = getopt(argc, argv, "46dhiyfFPvVl:nc:t:p")) != -1) {
 		switch (ch) {
 		case '4':
 			v4flag = 1;
 			break;
 		case '6':
 			v6flag = 1;
+			break;
+		case 'i':
+			insecure_transport = 1;
 			break;
 		case 'f':
 			force_update = 1;
@@ -146,6 +151,10 @@ main(int argc, char *argv[])
 	}
 	if (verbosity) {
 		fetchflags[ffidx++] = 'v';
+	}
+	strlcpy(insecurefetchflags, fetchflags, sizeof(insecurefetchflags));
+	if (!insecure_transport) {
+		fetchflags[ffidx++] = 'V';
 	}
 
 	/* Configure pkg_install */

--- a/pkgin.1.in
+++ b/pkgin.1.in
@@ -1,4 +1,4 @@
-.Dd July 1, 2020
+.Dd December 8, 2023
 .Dt PKGIN 1
 .Os
 .Sh NAME
@@ -6,7 +6,7 @@
 .Nd pkgsrc binary package manager
 .Sh SYNOPSIS
 .Nm
-.Op Fl 46dfhnPpVvy
+.Op Fl 46dfhinPpVvy
 .Op Fl c Ar chroot_path
 .Op Fl l Ar limit_chars
 .Op Fl t Ar log_file
@@ -42,6 +42,9 @@ Download only
 Force database update
 .It Fl h
 Displays help for the command
+.It Fl i
+Allow insecure downloads: bypass HTTPS certificate validation, allow
+HTTPS to redirect to HTTP/FTP
 .It Fl l Ar limit_chars
 Only include the packages with the specified
 .Dv STATUS FLAGS

--- a/pkgin.h
+++ b/pkgin.h
@@ -353,6 +353,8 @@ extern int		r_plistcounter;
 extern Plisthead	l_plisthead[LOCAL_PKG_HASH_SIZE];
 extern Plisthead	r_plisthead[REMOTE_PKG_HASH_SIZE];
 extern FILE		*tracefp;
+extern char		fetchflags[];
+extern char		insecurefetchflags[];
 
 /* download.c*/
 Sumfile		*sum_open(char *, time_t *);


### PR DESCRIPTION
New `-i` option to allow insecure transport.

Requires libfetch>=2.40.

References:
- [Proposal on tech-pkg](https://mail-index.netbsd.org/tech-pkg/2023/12/18/msg028629.html)
- [Discussion of related change to pkg_install](https://mail-index.netbsd.org/tech-pkg/2023/12/09/msg028594.html)

Note: In order to mitigate compatibility concerns, this doesn't require valid certs if an http repository _redirects_ to https, where it can't provide security against MITM attacks anyway.  This does, however, refuse to follow https redirects to http/ftp, in order to provide a reasonable security contract for users who explicitly ask for https in repositories.conf (unless they also ask for insecure transport with the `-i` option).  See [rationale for this approach](https://mail-index.netbsd.org/tech-pkg/2023/12/17/msg028624.html).