### PR TITLE
Logs should always have ISO8601 timestamps in UTC

### DIFF
--- a/actions.c
+++ b/actions.c
@@ -204,13 +204,14 @@ log_tag(const char *fmt, ...)
 	time_t		now;
 
 	now = time(NULL);
-	tim = *(localtime(&now));
+	tim = *(gmtime(&now));
 
 	va_start(ap, fmt);
 	vsnprintf(log_action, BUFSIZ, fmt, ap);
 	va_end(ap);
 
-	(void)strftime(now_date, DATELEN, "%b %d %H:%M:%S", &tim);
+	/* http://esr.ibiblio.org/?p=7901 */
+	(void)strftime(now_date, DATELEN, "%FT%TZ", &tim);
 
 	printf("%s", log_action);
 	if (!verbosity) {


### PR DESCRIPTION
I already have several systems with pkg histories spanning multiple years and
having the year in the pkg_install-err.log file would really help, and so given
that change it would also really be nice if log timestamps were in a more
sortable and parsable and standard format, and in a non-ambiguous common
timezone too (one which never suffers DST overlaps and gaps!)