### PR TITLE
Use an application id and user version number for schema.

### DIFF
--- a/pkgin.sql
+++ b/pkgin.sql
@@ -195,3 +195,6 @@ CREATE INDEX [idx_local_pkg_comment] ON [LOCAL_PKG] (
 CREATE INDEX [idx_local_pkg_name] ON [LOCAL_PKG] (
 	[PKGNAME] ASC
 );
+
+PRAGMA application_id = 1886087022;
+PRAGMA user_version = 1;

--- a/pkgindb_queries.c
+++ b/pkgindb_queries.c
@@ -27,17 +27,6 @@
  * SUCH DAMAGE.
  */
 
-/*
- * This query checks the compatibility of the current database, and should be
- * one that either completes or fails due to an SQL error based on the most
- * recent schema change.  Returned rows are ignored, so choose a query that
- * runs quickly.
- */
-const char CHECK_DB_LATEST[] =
-	"SELECT pkgbase "
-	"  FROM local_conflicts "
-	" LIMIT 1;";
-
 const char DELETE_LOCAL[] =
 	"DELETE FROM LOCAL_PKG;"
 	"DELETE FROM LOCAL_CONFLICTS;"


### PR DESCRIPTION
Rather than having to craft a new CHECK_DB_LATEST that fails with all old schema versions and works with the new schema version every time we make a schema change, we can just change the user_version number.